### PR TITLE
comment out GITHUB in values

### DIFF
--- a/charts/stable/littlelink-server/Chart.yaml
+++ b/charts/stable/littlelink-server/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: latest
 description: "A lightweight open source alternative to linktree"
 name: littlelink-server
-version: 3.0.0
+version: 3.0.1
 deprecated: true
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/stable/littlelink-server/values.yaml
+++ b/charts/stable/littlelink-server/values.yaml
@@ -28,7 +28,7 @@ env:
   AVATAR_ALT: Techno Tim Profile Pic
   NAME: TechnoTim
   BIO: Hey! Just a place where you can connect with me!
-  GITHUB: https://github.com/timothystewart6
+  # GITHUB: https://github.com/timothystewart6
   # TWITTER: https://twitter.com/TechnoTimLive
   # INSTAGRAM: https://www.instagram.com/techno.tim
   # YOUTUBE: https://www.youtube.com/channel/UCOk-gHyjcWZNj3Br4oxwh0A


### PR DESCRIPTION
Fixes #76

By commenting out this value, people can define a link page without the mandatory github button that is currently always going to appear.
